### PR TITLE
Integration test for Lightning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
-os:
-    - linux
 # Ubuntu 14.04 to use newer Boost version
+os:
+  - linux
 dist: trusty
 sudo: required
+
 compiler:
-    - gcc
+  - gcc
+
 addons:
   apt:
     packages:
       - libboost-all-dev
+      - httpie
+
 script: make && make test && make clean

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 os:
     - linux
+# Ubuntu 14.04 to use newer Boost version
+dist: trusty
 sudo: required
 compiler:
     - gcc
-before_install:
-    - sudo apt-get install libboost-all-dev
+addons:
+  apt:
+    packages:
+      - libboost-all-dev
 script: make && make test && make clean

--- a/Makefile
+++ b/Makefile
@@ -36,10 +36,8 @@ $(TESTS):
 	$(CXX) $(SRC_FLAGS) $(GTEST_FLAGS) $(TESTS).cc ${GTEST_DIR}/src/gtest_main.cc libgtest.a $(LIB_FLAGS) -o $(TESTS)
 
 test: $(TARGET) $(TESTS)
-	$(info ${\n}~~~~~~~~~~ Starting integration test. ~~~~~~~~~~${\n})
-	python lightning_integration_test.py
-	$(info ~~~~~~~~~~ Integration test successful, starting unit tests. ~~~~~~~~~~${\n})
 	./$(TESTS)
+	python3 lightning_integration_test.py
 
 clean:
 	$(RM) $(TARGET) $(TESTS) *.o *.a

--- a/Makefile
+++ b/Makefile
@@ -8,20 +8,38 @@ SRC_FLAGS = -std=c++0x -I nginx-configparser/ -Wall -Wextra
 # TODO: This should be named LDFLAGS for consistency with the Makefile community
 LIB_FLAGS = -lpthread -lboost_system
 PARSER_PATH = ./nginx-configparser/
+GTEST_DIR = nginx-configparser/googletest/googletest
+GTEST_FLAGS = -isystem ${GTEST_DIR}/include
 
-# TODO: Make a phony, so that targets are not treated as files on-disk
 # TODO: Split out dependency handling so that we can avoid rebuilding
+.PHONY: $(TARGET) $(TESTS) all test clean
 
 TARGET = lightning
+TESTS = lightning_server_test
 SRC = $(PARSER_PATH)config_parser.cc lightning_main.cc lightning_server.cc
+
+define \n
+
+
+endef
 
 all: $(TARGET)
 
 $(TARGET): $(SRC)
 	$(CXX) $(SRC_FLAGS) $(SRC) $(LIB_FLAGS) -o $(TARGET)
 
-test:
-	python3 lightning_integration_test.py
+# TODO: Generalize for multiple unit tests
+# TODO: These assume compilation on LINUX, need to add OS check
+$(TESTS):
+	$(CXX) $(SRC_FLAGS) $(GTEST_FLAGS) -I${GTEST_DIR} -c ${GTEST_DIR}/src/gtest-all.cc
+	ar -rv libgtest.a gtest-all.o
+	$(CXX) $(SRC_FLAGS) $(GTEST_FLAGS) $(TESTS).cc ${GTEST_DIR}/src/gtest_main.cc libgtest.a $(LIB_FLAGS) -o $(TESTS)
+
+test: $(TARGET) $(TESTS)
+	$(info ${\n}~~~~~~~~~~ Starting integration test. ~~~~~~~~~~${\n})
+	python lightning_integration_test.py
+	$(info ~~~~~~~~~~ Integration test successful, starting unit tests. ~~~~~~~~~~${\n})
+	./$(TESTS)
 
 clean:
-	$(RM) $(TARGET)
+	$(RM) $(TARGET) $(TESTS) *.o *.a

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,16 @@
 # Based on example Makefile:
 # https://www.cs.swarthmore.edu/~newhall/unixhelp/howto_makefiles.html
+
+# TODO: CXX is a predefined variable. What is its default value on different platforms?
+# TODO: MAKEOPTS += 2 (to parallelize building with 2 commands at once)
 CXX = g++
-SRC_FLAGS = -std=c++0x -I nginx-configparser/
+SRC_FLAGS = -std=c++0x -I nginx-configparser/ -Wall -Wextra
+# TODO: This should be named LDFLAGS for consistency with the Makefile community
 LIB_FLAGS = -lpthread -lboost_system
 PARSER_PATH = ./nginx-configparser/
+
+# TODO: Make a phony, so that targets are not treated as files on-disk
+# TODO: Split out dependency handling so that we can avoid rebuilding
 
 TARGET = lightning
 SRC = $(PARSER_PATH)config_parser.cc lightning_main.cc lightning_server.cc

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 # Based on example Makefile:
 # https://www.cs.swarthmore.edu/~newhall/unixhelp/howto_makefiles.html
 
-# TODO: CXX is a predefined variable. What is its default value on different platforms?
-# TODO: MAKEOPTS += 2 (to parallelize building with 2 commands at once)
+MAKEOPTS = "-j 2"
+
 CXX = g++
 SRC_FLAGS = -std=c++0x -I nginx-configparser/ -Wall -Wextra
-# TODO: This should be named LDFLAGS for consistency with the Makefile community
-LIB_FLAGS = -lpthread -lboost_system
+LDFLAGS = -lpthread -lboost_system
+
 PARSER_PATH = ./nginx-configparser/
 GTEST_DIR = nginx-configparser/googletest/googletest
 GTEST_FLAGS = -isystem ${GTEST_DIR}/include
@@ -18,22 +18,17 @@ TARGET = lightning
 TESTS = lightning_server_test
 SRC = $(PARSER_PATH)config_parser.cc lightning_main.cc lightning_server.cc
 
-define \n
-
-
-endef
-
 all: $(TARGET)
 
 $(TARGET): $(SRC)
-	$(CXX) $(SRC_FLAGS) $(SRC) $(LIB_FLAGS) -o $(TARGET)
+	$(CXX) $(SRC_FLAGS) $(SRC) $(LDFLAGS) -o $(TARGET)
 
 # TODO: Generalize for multiple unit tests
-# TODO: These assume compilation on LINUX, need to add OS check
+# TODO: These assume compilation on LINUX, so we need to add an OS check
 $(TESTS):
 	$(CXX) $(SRC_FLAGS) $(GTEST_FLAGS) -I${GTEST_DIR} -c ${GTEST_DIR}/src/gtest-all.cc
 	ar -rv libgtest.a gtest-all.o
-	$(CXX) $(SRC_FLAGS) $(GTEST_FLAGS) $(TESTS).cc ${GTEST_DIR}/src/gtest_main.cc libgtest.a $(LIB_FLAGS) -o $(TESTS)
+	$(CXX) $(SRC_FLAGS) $(GTEST_FLAGS) $(TESTS).cc ${GTEST_DIR}/src/gtest_main.cc libgtest.a $(LDFLAGS) -o $(TESTS)
 
 test: $(TARGET) $(TESTS)
 	./$(TESTS)

--- a/lightning_integration_test.py
+++ b/lightning_integration_test.py
@@ -1,14 +1,37 @@
 #!/usr/bin/env python
 
-from subprocess import call
+import subprocess
+from subprocess import run
 
 print("START Lightning integration tests\n")
 
 # make -s suppresses output of commands as make executes them
+# subprocess.run returns a CompletedProcess object
 if (
-    call(['make', '-s', 'clean']) != 0 or
-    call(['make', '-s']) != 0
+    run(['make', '-s', 'clean']).returncode != 0 or
+    run(['make', '-s']).returncode != 0
    ):
-    print('FAILED: Build and run with simple_config failed!')
+    print('FAILED: Build with make failed!')
+
+# Test echoing
+# Try a background fork/thread
+if (run(['./lightning', 'simple_config']).returncode != 0):
+    print('FAILED: Lightning server failed to start with simple config')
+
+# TODO: Have intermediate logging throughout
+# TODO: Use Python unit test frameworks + logging libraries
+print("After server start")
+
+# TODO: HTTPie is failing to run
+original_request = 'GET / HTTP/1.1\r\nHost: localhost:8080\r\nUser-Agent: HTTPie/0.9.8\r\nAccept-Encoding: gzip, deflate\r\nAccept: */*\r\nConnection: keep-alive\r\n\r\n'
+completed_request = run(['http', 'localhost:8080'], stdout=subprocess.PIPE)
+
+if (completed_request.returncode != 0 or
+    completed_request.stdout != original_request
+   ):
+    print('FAILED: httpie received a non-matching echo response')
+
+# Terminate the server
+run(['pkill', 'lightning'])
 
 print("\nEND Lightning integration tests. All tests passed!")

--- a/lightning_integration_test.py
+++ b/lightning_integration_test.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 
+# NOTE: subprocess.run requires Python 3.5+
 import subprocess
 from subprocess import run
 
-print("START Lightning integration tests\n")
+print("\nSTART Lightning integration tests\n")
 
 # make -s suppresses output of commands as make executes them
 # subprocess.run returns a CompletedProcess object
@@ -13,25 +14,29 @@ if (
    ):
     print('FAILED: Build with make failed!')
 
+print('SUCCESS: make clean and make')
+
 # Test echoing
 # Try a background fork/thread
-if (run(['./lightning', 'simple_config']).returncode != 0):
-    print('FAILED: Lightning server failed to start with simple config')
+server_process = subprocess.Popen(['./lightning', 'simple_config'])
 
 # TODO: Have intermediate logging throughout
 # TODO: Use Python unit test frameworks + logging libraries
-print("After server start")
+print('DEBUG: Lightning server started!')
 
-# TODO: HTTPie is failing to run
-original_request = 'GET / HTTP/1.1\r\nHost: localhost:8080\r\nUser-Agent: HTTPie/0.9.8\r\nAccept-Encoding: gzip, deflate\r\nAccept: */*\r\nConnection: keep-alive\r\n\r\n'
+original_request = b'GET / HTTP/1.1\r\nHost: localhost:8080\r\nUser-Agent: HTTPie/0.9.8\r\nAccept-Encoding: gzip, deflate\r\nAccept: */*\r\nConnection: keep-alive\r\n\r\n'
 completed_request = run(['http', 'localhost:8080'], stdout=subprocess.PIPE)
 
-if (completed_request.returncode != 0 or
-    completed_request.stdout != original_request
-   ):
+if (completed_request.returncode != 0):
+    print('FAILED: httpie encountered an error')
+
+if (completed_request.stdout != original_request):
     print('FAILED: httpie received a non-matching echo response')
+    print('Completed request: \n%s' % completed_request.stdout.decode('UTF-8'))
+
+print('SUCCESS: HTTPie request echo')
 
 # Terminate the server
-run(['pkill', 'lightning'])
+server_process.kill()
 
 print("\nEND Lightning integration tests. All tests passed!")

--- a/lightning_integration_test.py
+++ b/lightning_integration_test.py
@@ -24,15 +24,15 @@ server_process = subprocess.Popen(['./lightning', 'simple_config'])
 # TODO: Use Python unit test frameworks + logging libraries
 print('DEBUG: Lightning server started!')
 
-original_request = b'GET / HTTP/1.1\r\nHost: localhost:8080\r\nUser-Agent: HTTPie/0.9.8\r\nAccept-Encoding: gzip, deflate\r\nAccept: */*\r\nConnection: keep-alive\r\n\r\n'
-completed_request = run(['http', 'localhost:8080'], stdout=subprocess.PIPE)
+expected_response = b'GET / HTTP/1.1\r\nHost: localhost:8080\r\nUser-Agent: HTTPie/0.9.8\r\nAccept-Encoding: gzip, deflate\r\nAccept: */*\r\nConnection: keep-alive\r\n\r\n'
+actual_response = run(['http', 'localhost:8080'], stdout=subprocess.PIPE)
 
-if (completed_request.returncode != 0):
+if (actual_response.returncode != 0):
     print('FAILED: httpie encountered an error')
 
-if (completed_request.stdout != original_request):
+if (actual_response.stdout != expected_response):
     print('FAILED: httpie received a non-matching echo response')
-    print('Completed request: \n%s' % completed_request.stdout.decode('UTF-8'))
+    print('Completed request: \n%s' % actual_response.stdout.decode('UTF-8'))
 
 print('SUCCESS: HTTPie request echo')
 

--- a/lightning_server_test.cc
+++ b/lightning_server_test.cc
@@ -1,0 +1,16 @@
+#include <sstream>
+#include <string>
+
+#include "lightning_server.h"
+#include "gtest/gtest.h"
+
+TEST(TestTests, FirstTest) {
+  EXPECT_EQ(1, 1)
+    << "This should succeed!";
+}
+
+TEST(TestTests, SecondTest) {
+  EXPECT_EQ(1, 2)
+    << "This should fail, seeing this message is good!";
+}
+

--- a/lightning_server_test.cc
+++ b/lightning_server_test.cc
@@ -9,8 +9,3 @@ TEST(TestTests, FirstTest) {
     << "This should succeed!";
 }
 
-TEST(TestTests, SecondTest) {
-  EXPECT_EQ(1, 2)
-    << "This should fail, seeing this message is good!";
-}
-


### PR DESCRIPTION
This adds a basic integration test for Lightning. The test: 

* Starts the server
* Sends a request using HTTPie
* Checks that the echoed response contains the original request in its body, and has the correct headers
* Kills the server

TODO: 
* [x] Remove intermediate build artifacts as part of [make clean](https://github.com/UCLA-CS130/Mr.-Robot-et-al./blob/echo-server-tests/Makefile#L27) (Done by https://github.com/UCLA-CS130/Mr.-Robot-et-al./pull/6/commits/db7b803217a362505b7944fc7543f8039c4241c4)
* [x] Make the integration test pass