### PR TITLE
Refactor handlers to use response buffer outparam

### DIFF
--- a/request_handlers.cc
+++ b/request_handlers.cc
@@ -10,32 +10,20 @@ using namespace lightning_server;
 // Read in the request from the socket used to construct the handler, then
 // fill the response buffer with the necessary headers followed by the
 // original request.
-char* request_handlers::echoRequestHandler(boost::shared_ptr<tcp::socket> socket,
-                                           char* response_buffer,
-                                           size_t& response_buffer_size) {
-  // Read in request
-  char request_buffer[MAX_REQ_SIZE];
-  boost::system::error_code ec;
-  std::size_t bytes_read = socket->read_some(boost::asio::buffer(request_buffer), ec);
-  switch (ec.value()) {
-    case boost::system::errc::success:
-      std::cout << "~~~~~~~~~~Request~~~~~~~~~~\n" << request_buffer << std::endl;
-      break;
-    default:
-      std::cout << "Error reading from socket, code: " << ec << std::endl;
-      return nullptr;
-  }
+void request_handlers::echoRequestHandler(char* request_buffer,
+                                          char* response_buffer,
+                                          size_t& response_buffer_size) {
 
   // Create response, defaulting to 200 OK status code for now
   const std::string response_header = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n";
   std::size_t header_size = response_header.size();
-  size_t response_size = header_size + bytes_read;
+  size_t response_size = header_size + response_buffer_size;
 
+  // TODO: need to check if we need to resize response buffer, if response is huge
   response_header.copy(response_buffer, header_size);
-  std::memcpy(&response_buffer[header_size], request_buffer, bytes_read);
+  std::memcpy(&response_buffer[header_size], request_buffer, response_buffer_size);
   std::cout << "~~~~~~~~~~Response~~~~~~~~~~\n" << response_buffer << std::endl;
-  
+
   response_buffer_size = response_size;
-  return response_buffer;
 }
 

--- a/request_handlers.h
+++ b/request_handlers.h
@@ -10,9 +10,9 @@ namespace lightning_server {
   // to be written back to the client.
   namespace request_handlers {
     // Echo the request that was received
-    char* echoRequestHandler(boost::shared_ptr<tcp::socket> socket,
-                             char* response_buffer,
-                             size_t& response_buffer_size);
+    void echoRequestHandler(char* request_buffer,
+                            char* response_buffer,
+                            size_t& response_buffer_size);
   }
 }
 


### PR DESCRIPTION
Instead of returning the response buffer, we pass it as a parameter
to the handler along with the request buffer. By doing this, it
becomes much easier to unit test the echoHandler as we don't have
to deal with passing around a socket pointer.