### PR TITLE
Test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,6 @@ addons:
     packages:
       - libboost-all-dev
       - httpie
+      - lcov
 
 script: make && make test && make clean

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ LDFLAGS = -lpthread -lboost_system
 PARSER_PATH = ./nginx-configparser/
 GTEST_DIR = nginx-configparser/googletest/googletest
 GTEST_FLAGS = -isystem ${GTEST_DIR}/include
-TEST_COV = -fprofile-arcs -ftest-coverage
+TEST_COV = --coverage # --coverage is a synonym for-fprofile-arcs, -ftest-coverage(compiling) and-lgcov(linking).
 
 # TODO: Split out dependency handling so that we can avoid rebuilding
 .PHONY: $(TARGET) $(TESTS) all test integration_test clean
@@ -39,8 +39,10 @@ $(TESTS):
 integration_test: $(TARGET) $(TESTS)
 	./$(TESTS)
 	./$(TARGET) simple_config &
+	lcov -t "Lightning Coverage" -o test_coverage.info -c -d .
+	genhtml -o test_coverage test_coverage.info
 	python3 lightning_integration_test.py
 	pkill $(TARGET)
 
 clean:
-	$(RM) $(TARGET) $(TESTS) *.o *.a *.gcov *.gcno *.gcda
+	$(RM) $(TARGET) $(TESTS) *.o *.a *.gcov *.gcno *.gcda -r test_coverage*

--- a/Makefile
+++ b/Makefile
@@ -9,15 +9,19 @@ LDFLAGS = -lpthread -lboost_system
 PARSER_PATH = ./nginx-configparser/
 GTEST_DIR = nginx-configparser/googletest/googletest
 GTEST_FLAGS = -isystem ${GTEST_DIR}/include
+TEST_COV = -fprofile-arcs -ftest-coverage
 
 # TODO: Split out dependency handling so that we can avoid rebuilding
-.PHONY: $(TARGET) $(TESTS) all test clean
+.PHONY: $(TARGET) $(TESTS) all test integration_test clean
 
 TARGET = lightning
 TESTS = server_config_test
 SRC = $(PARSER_PATH)config_parser.cc lightning_main.cc lightning_server.cc server_config.cc request_handlers.cc
 
 all: $(TARGET)
+
+test: LDFLAGS += $(TEST_COV)
+test: integration_test
 
 $(TARGET): $(SRC)
 	$(CXX) $(SRC_FLAGS) $(SRC) $(LDFLAGS) -o $(TARGET)
@@ -32,11 +36,11 @@ $(TESTS):
 	# TODO: Figure out how to name multiple CC and produce corresponding object for each
 	$(CXX) $(SRC_FLAGS) $(GTEST_FLAGS) $(PARSER_PATH)config_parser.cc server_config.cc $(TESTS).cc ${GTEST_DIR}/src/gtest_main.cc libgtest.a $(LDFLAGS) -o $(TESTS)
 
-test: $(TARGET) $(TESTS)
+integration_test: $(TARGET) $(TESTS)
 	./$(TESTS)
 	./$(TARGET) simple_config &
 	python3 lightning_integration_test.py
 	pkill $(TARGET)
 
 clean:
-	$(RM) $(TARGET) $(TESTS) *.o *.a
+	$(RM) $(TARGET) $(TESTS) *.o *.a *.gcov *.gcno *.gcda


### PR DESCRIPTION
Modified our Makefile to automate the process of generating test coverage data and generating a nice web front-end with the `lcov` and `genhtml` tools. The `index.html` file can be found in the `test_coverage` directory that is generated after running `make test`, which will run our unit tests, generate test coverage data files, and finally our integration test.