### PR TITLE
Allow routing to be set from the config file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ SRC = $(PARSER_PATH)config_parser.cc lightning_main.cc lightning_server.cc serve
 all: $(TARGET)
 
 test: LDFLAGS += $(TEST_COV)
-test: integration_test
+test: clean integration_test
 
 $(TARGET): $(SRC)
 	$(CXX) $(SRC_FLAGS) $(SRC) $(LDFLAGS) -o $(TARGET)

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ SRC = $(PARSER_PATH)config_parser.cc lightning_main.cc lightning_server.cc serve
 all: $(TARGET)
 
 test: LDFLAGS += $(TEST_COV)
-test: clean integration_test
+test: integration_test
 
 $(TARGET): $(SRC)
 	$(CXX) $(SRC_FLAGS) $(SRC) $(LDFLAGS) -o $(TARGET)

--- a/lightning_server.cc
+++ b/lightning_server.cc
@@ -15,7 +15,15 @@ LightningServer::LightningServer(const char* file_name)
   config_parser_.Parse(file_name, &config_);
   std::cout << config_.ToString() << std::endl;
   ServerConfig ConfigWrapper(config_);
-  port_ = ConfigWrapper.propertyLookUp("port");
+  // TODO: with new ServerConfig class, we expect the port to be stored found
+  // in the config with the following format:
+  // server {
+  //     ...
+  //     listen $(PORT);
+  //     ...
+  // }
+  std::vector<std::string> query = {"server", "listen"};
+  ConfigWrapper.propertyLookUp(query, &port_);
   std::cout << port_ << std::endl;
 }
 

--- a/lightning_server.cc
+++ b/lightning_server.cc
@@ -14,7 +14,7 @@ LightningServer::LightningServer(const char* file_name)
 {
   config_parser_.Parse(file_name, &config_);
   std::cout << config_.ToString() << std::endl;
-  ServerConfig ConfigWrapper(config_);
+  ServerConfig config_wrapper(config_);
   // TODO: with new ServerConfig class, we expect the port to be stored found
   // in the config with the following format:
   // server {
@@ -23,7 +23,7 @@ LightningServer::LightningServer(const char* file_name)
   //     ...
   // }
   std::vector<std::string> query = {"server", "listen"};
-  ConfigWrapper.propertyLookUp(query, &port_);
+  config_wrapper.propertyLookUp(query, port_);
   std::cout << port_ << std::endl;
 }
 

--- a/server_config.cc
+++ b/server_config.cc
@@ -4,54 +4,92 @@
 #include <string>
 
 ServerConfig::ServerConfig(NginxConfig config) {
-  fillOutMap(config);
+  std::vector<std::string> basePath = {};
+  fillOutMap(config, basePath);
+  printPropertiesMap();
 }
 
-ServerConfig::~ServerConfig() {
-  // TODO
+ServerConfig::~ServerConfig() {}
+
+// TODO: is this a terrible function name?
+// Helper function to concatenate multi-word config parameter names
+std::string buildWordyParam(std::shared_ptr<NginxConfigStatement> statement,
+                            size_t valueSize) {
+  size_t numTokens = statement->tokens_.size();
+  std::string paramName = "";
+
+  for (size_t i = 0; i < numTokens-valueSize; i++) {
+    if (paramName != "")
+      paramName += " ";
+    paramName += statement->tokens_[i];
+  }
+
+  return paramName;
 }
 
-void ServerConfig::fillOutMap(NginxConfig config) {
-  // Initialize variables property, value
-  std::string property = "";
-  std::string value = "";
+// In NgnixConfig, Statements are root level 'blocks' (e.g. server {})
+// fillOutMap will recursively construct an unordered_map between a vector of strings
+// representing the 'path' to a config parameter and the value of that parameter
+//   e.g. ["server", "listen"] should be mapped to the port number
+void ServerConfig::fillOutMap(NginxConfig config, std::vector<std::string> basePath) {
+  if (config.statements_.size() < 1) {
+    // TODO: Possible logging here about empty config
+    return;
+  }
+
+  // Loop through all config param block at the current depth
   for (size_t i = 0; i < config.statements_.size(); i++) {
-    //search in child block
-    if (config.statements_[i]->child_block_ != nullptr) {
-      fillOutMap(*(config.statements_[i]->child_block_));
+    size_t numTokens = config.statements_[i]->tokens_.size();
+    if (numTokens < 1) {
+      std::cout << "Invalid statement: no value associated with param\n";
+      std::cout << config.statements_[i]->ToString(5) << std::endl;
+      return;
     }
-
-    if (config.statements_[i]->tokens_.size() >= 1) {
-      property = config.statements_[i]->tokens_[0];
+    else if (config.statements_[i]->child_block_ != nullptr) {
+      // Dealing with an NginxConfig Block
+      std::vector<std::string> basePathExtended = basePath;
+      basePathExtended.push_back(buildWordyParam(config.statements_[i], 0));
+      fillOutMap(*(config.statements_[i]->child_block_), basePathExtended);
     }
-
-    if (config.statements_[i]->tokens_.size() >= 2) {
-      value = config.statements_[i]->tokens_[1];
-    }
-
-    if (property == "listen" && value != "") {
-      property_to_values_["port"] = value;
+    else {
+      // Dealing with an NginxConfigStatement
+      // LeafTokens denote the number of 'words' in a statement w/o a child block
+      size_t numLeafTokens = config.statements_[i]->tokens_.size();
+      std::vector<std::string> finalPath = basePath;
+      finalPath.push_back(buildWordyParam(config.statements_[i], 1));
+      path_to_values_[finalPath] = config.statements_[i]->tokens_[numLeafTokens-1];
     }
   }
 }
 
+// Print the contents of the mapping of 'path to config param' -> value
 void ServerConfig::printPropertiesMap() {
   // Iterate over an unordered_map using range based for loop
   std::cout << "Mappings in property_to_values_:\n" << std::endl;
-  for (std::pair<std::string, std::string> element : property_to_values_) {
-    std::cout << element.first << " :: " << element.second << std::endl;
+  for (std::pair<std::vector<std::string>, std::string> element : path_to_values_) {
+    for (auto const& key : element.first) {
+      std::cout << key << ".";
+    }
+    std::cout << " -> " << element.second << std::endl;
   }
 }
 
-std::string ServerConfig::propertyLookUp(std::string propertyName) {
+// The outward facing interface of ServerConfig, returns an int representing the
+// status of the call and sets in *val, the value of the property passed in.
+// TODO: check return val? returns 0 on success, nonzero on any error
+int ServerConfig::propertyLookUp(const std::vector<std::string>& propertyPath, std::string* val) {
   // unordered_map::at(key) throws if key not found.
   // unordered_map::operator[key] will silently create that entry
   // See: http://www.cplusplus.com/reference/unordered_map/unordered_map/operator[]/
   // and: http://www.cplusplus.com/reference/stdexcept/out_of_range/
   try {
-    return property_to_values_.at(propertyName);
+    // TODO: add logging output here
+    *val = path_to_values_.at(propertyPath);
+    return 0;
   }
   catch (const std::out_of_range& oor) {
-    return "";
+    // TODO: add logging output here
+    // TODO: give some error code which the handlers can interpret to return 404,etc.
+    return 1;
   }
 }

--- a/server_config.h
+++ b/server_config.h
@@ -2,18 +2,31 @@
 #define SERVER_CONFIG_H
 
 #include "config_parser.h"
+#include <boost/functional/hash.hpp>
 #include <unordered_map>
+#include <vector>
+
+// From: https://stackoverflow.com/questions/10405030/c-unordered-map-fail-when-used-with-a-vector-as-key
+// Allows us to use a vector as a key in an unordered_map by passing in a hash function when declaring the unordered_map.
+template <typename Container>
+struct container_hash {
+  std::size_t operator()(Container const& c) const {
+    return boost::hash_range(c.begin(), c.end());
+  }
+};
 
 class ServerConfig {
   public:
     ServerConfig(NginxConfig config);
     ~ServerConfig();
-    std::string propertyLookUp(std::string propertyName);
+    int propertyLookUp(const std::vector<std::string>& propertyPath, std::string* val);
 
   private:
     void printPropertiesMap();
-    void fillOutMap(NginxConfig config);
-    std::unordered_map<std::string,std::string> property_to_values_;
+    void fillOutMap(NginxConfig config, std::vector<std::string>);
+    std::unordered_map<std::vector<std::string>,
+                       std::string,
+                       container_hash<std::vector<std::string>>> path_to_values_;
 };
 
 #endif

--- a/server_config.h
+++ b/server_config.h
@@ -18,8 +18,8 @@ struct container_hash {
 class ServerConfig {
   public:
     ServerConfig(NginxConfig config);
-    ~ServerConfig();
-    int propertyLookUp(const std::vector<std::string>& propertyPath, std::string* val);
+    int propertyLookUp(const std::vector<std::string>& propertyPath,
+                       std::string& val);
 
   private:
     void printPropertiesMap();

--- a/server_config_test.cc
+++ b/server_config_test.cc
@@ -165,6 +165,6 @@ TEST_F(ServerConfigTest, MultiWordProperties) {
     EXPECT_EQ(0, ec)
       << "Error value of 0 should be returned if property is found";
     EXPECT_EQ("echo", action)
-      << "A listen property with a port number in a nested block with \
-          other properties and newlines should yield a port number";
+      << "Requesting the action property should yield echo in this config.";
 }
+

--- a/simple_config
+++ b/simple_config
@@ -1,3 +1,17 @@
 server {
     listen  8080;
+
+    location /echo {
+        action echo;
+    }
+
+    location /static1 {
+        root /home/files/cats;
+        action serve;
+    }
+
+    location /static2 {
+        root /home/files/birds;
+        action serve;
+    }
 }


### PR DESCRIPTION
Instead of passing in a config parameter name (for ex: "port"), we
pass in a path to the desired parameter. For the case of port, we
would use ["server", "listen"]. This allows us to use nested blocks
in our config file, which we use for setting up the routing in our
web server. This routing specifies the base url from which files
will be served as well as the Handler which will handle the
response.

Included is a sample config file which shows off the structure of the
Routing, however the translation and convention between the name
of the handler in the config and which handler is called has yet to be
implemented.