### PR TITLE
Implement synchronous multithreading using Boost::Threads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ MAKEOPTS = "-j 2"
 
 CXX = g++
 SRC_FLAGS = -std=c++0x -I nginx-configparser/ -Wall -Wextra
-LDFLAGS = -lpthread -lboost_filesystem -lboost_system
+LDFLAGS = -lpthread -lboost_filesystem -lboost_system -lboost_thread
 
 PARSER_PATH = ./nginx-configparser/
 GTEST_DIR = nginx-configparser/googletest/googletest

--- a/lightning_integration_test.py
+++ b/lightning_integration_test.py
@@ -6,16 +6,23 @@ from subprocess import run
 
 print("\nSTART Lightning integration tests\n")
 
-# Test echoing
+# Test echoing using httpie
 # Try a background fork/thread
 server_process = subprocess.Popen(['./lightning', 'simple_config'])
+
+# Spawn a shell process to act as hanging http request
+telnet_request_command = "telnet localhost 2020"
+telnet_request_proc = subprocess.Popen(telnet_request_command, stdout=subprocess.PIPE, shell=True)
 
 # TODO: Have intermediate logging throughout
 # TODO: Use Python unit test frameworks + logging libraries
 print('DEBUG: Lightning server started!')
 
-expected_response = b'GET / HTTP/1.1\r\nHost: localhost:8080\r\nUser-Agent: HTTPie/0.9.8\r\nAccept-Encoding: gzip, deflate\r\nAccept: */*\r\nConnection: keep-alive\r\n\r\n'
-actual_response = run(['http', 'localhost:8080'], stdout=subprocess.PIPE)
+# as the telnet is hanging, we will perform an echo request, which should still be 
+# handled by a separate handler in a new thread; it will still succeed and return 
+# a response instantly.
+expected_response = b'GET /echo HTTP/1.1\r\nHost: localhost:2020\r\nAccept-Encoding: gzip, deflate, compress\r\nAccept: */*\r\nUser-Agent: HTTPie/0.8.0\r\n\r\n'
+actual_response = run(['http', 'localhost:2020/echo'], stdout=subprocess.PIPE)
 
 if (actual_response.returncode != 0):
     print('FAILED: httpie encountered an error')
@@ -23,8 +30,8 @@ if (actual_response.returncode != 0):
 if (actual_response.stdout != expected_response):
     print('FAILED: httpie received a non-matching echo response')
     print('Completed request: \n%s' % actual_response.stdout.decode('UTF-8'))
-
-print('SUCCESS: HTTPie request echo')
+else:
+    print('SUCCESS: HTTPie request echo; Multithreading successful!')
 
 # Terminate the server
 server_process.kill()

--- a/lightning_server.cc
+++ b/lightning_server.cc
@@ -88,13 +88,15 @@ void LightningServer::start() {
   }
 
   // Set the number of threads if specified in the config
-  std::vector<std::string> query_path = {"numThreads"};
+  std::vector<std::string> query_path = {"num_threads"};
   std::string num_threads;
   bool found_threads = server_config_.propertyLookUp(query_path, num_threads);
-  num_threads_ = std::stoi(num_threads);
   if (!found_threads) {
     std::cout << "Number of threads not specified in config: defaulting to 0\n";
     num_threads_ = 0;
+  }
+  else {
+    num_threads_ = std::stoi(num_threads);
   }
 
   // Setup server to listen for TCP connection on config file specified port

--- a/lightning_server.h
+++ b/lightning_server.h
@@ -19,6 +19,7 @@ class LightningServer {
     boost::asio::io_service io_service_;
     boost::asio::ip::tcp::acceptor acceptor_;
     std::string port_;
+    std::size_t num_threads_;
 };
 
 #endif

--- a/server_stats.cc
+++ b/server_stats.cc
@@ -17,6 +17,7 @@ void ServerStats::recordInteraction(Request request, Response response) {
   // Construct tuple of [full_uri, status_code]
   std::vector<string> uri_and_status = { request.uri(), response.statusCode() };
 
+  std::lock_guard<std::mutex> lock(mutex_);
   // Increment its count or initialize its count as 0 if never seen before
   const auto it = handler_call_distribution_.find(uri_and_status);
   if (it == handler_call_distribution_.end()) {

--- a/server_stats.cc
+++ b/server_stats.cc
@@ -1,5 +1,18 @@
 #include "server_stats.h"
 
+void ServerStats::init(ServerConfig server_config) {
+
+  for (const auto path : server_config.allPaths()) {
+    const std::string uri_prefix = path.first;
+    const std::string handler_name = path.second;
+
+    if (handler_name == "StatusHandler") {
+      std::vector<string> uri_and_status = { uri_prefix, "200" };
+      handler_call_distribution_[uri_and_status] = 1;
+    }
+  }
+}
+
 void ServerStats::recordInteraction(Request request, Response response) {
   // Construct tuple of [full_uri, status_code]
   std::vector<string> uri_and_status = { request.uri(), response.statusCode() };

--- a/server_stats.h
+++ b/server_stats.h
@@ -22,6 +22,9 @@ struct tuple_hash {
 
 class ServerStats {
   public:
+    // Initialize distribution with one sucessful call to /status
+    void init(ServerConfig server_config);
+
     // Record a Request/Response pair
     void recordInteraction(Request request, Response response);
 

--- a/server_stats.h
+++ b/server_stats.h
@@ -5,6 +5,7 @@
 #include "response.h"
 #include "server_config.h"
 
+#include <mutex>
 #include <unordered_map>
 #include <vector>
 #include <string>
@@ -48,6 +49,7 @@ class ServerStats {
     std::unordered_map<std::vector<string>,
                        int,
                        tuple_hash<std::vector<string>>> handler_call_distribution_;
+    std::mutex mutex_;
 };
 
 #endif SERVER_STATS_H

--- a/simple_config
+++ b/simple_config
@@ -2,7 +2,7 @@
 
 port 2020;  # This is also a comment.
 
-numThreads 5;
+num_threads 5;
 
 path /static StaticRequestHandler {
   root /test;

--- a/simple_config
+++ b/simple_config
@@ -2,6 +2,8 @@
 
 port 2020;  # This is also a comment.
 
+numThreads 5;
+
 path /static StaticRequestHandler {
   root /test;
 }


### PR DESCRIPTION
Most handlers except for StatusHandler are thread-safe, which requires the use of a mutex in order to prevent race conditions when initializing the count of request and return status.

The `std::mutex` is safely freed by encapsulating it in a `std::lock_guard`, which unlocks the resource when it goes out of scope. 

We also added a new config parameter, `numThreads` which can be used to set the number of threads spawned in a thread pool, which we don't currently support.